### PR TITLE
Minor changes/fixes to bibtex rendering

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -546,7 +546,7 @@ An example report
   A two-stage masking procedure was applied, in which a liberal mask (including voxels with good data in at least the first echo) was used for optimal combination, T2*/S0 estimation, and denoising, while a more conservative mask (restricted to voxels with good data in at least the first three echoes) was used for the component classification procedure.
   Multi-echo data were then optimally combined using the T2* combination method \\citep{posse1999enhancement}.
   Next, components were manually classified as BOLD (TE-dependent), non-BOLD (TE-independent), or uncertain (low-variance).
-  This workflow used numpy \\citep{van2011numpy}, scipy \\citep{virtanen2020scipy}, pandas \\citep{mckinney2010data,reback2020pandas}, scikit-learn \\citep{pedregosa2011scikit}, nilearn, bokeh \\citep{bokehmanual}, matplotlib \\citep{Hunter:2007}, and nibabel \\citep{brett_matthew_2019_3233118}.
+  This workflow used numpy \\citep{van2011numpy}, scipy \\citep{virtanen2020scipy}, pandas \\citep{mckinney2010data,reback2020pandas}, scikit-learn \\citep{pedregosa2011scikit}, nilearn, bokeh \\citep{bokehmanual}, matplotlib \\citep{Hunter2007}, and nibabel \\citep{brett_matthew_2019_3233118}.
   This workflow also used the Dice similarity index \\citep{dice1945measures,sorensen1948method}.
 
   References

--- a/tedana/bibtex.py
+++ b/tedana/bibtex.py
@@ -123,9 +123,9 @@ def find_citations(description):
     all_citations : :obj:`list` of :obj:`str`
         A list of all identifiers for citations.
     """
-    paren_citations = re.findall(r"\\citep{([a-zA-Z0-9,/\.]+)}", description)
-    intext_citations = re.findall(r"\\cite{([a-zA-Z0-9,/\.]+)}", description)
-    inparen_citations = re.findall(r"\\citealt{([a-zA-Z0-9,/\.]+)}", description)
+    paren_citations = re.findall(r"\\citep{([a-zA-Z0-9,_/\.]+)}", description)
+    intext_citations = re.findall(r"\\cite{([a-zA-Z0-9,_/\.]+)}", description)
+    inparen_citations = re.findall(r"\\citealt{([a-zA-Z0-9,_/\.]+)}", description)
     all_citations = ",".join(paren_citations + intext_citations + inparen_citations)
     all_citations = all_citations.split(",")
     all_citations = sorted(list(set(all_citations)))

--- a/tedana/reporting/data/html/report_body_template.html
+++ b/tedana/reporting/data/html/report_body_template.html
@@ -182,7 +182,7 @@
     <h1>About tedana</h1>
     $about
   </div>
-  <div class="references">
+  <div class="content references">
     <h1>References</h1>
     <ul>
       $references

--- a/tedana/reporting/data/html/report_body_template.html
+++ b/tedana/reporting/data/html/report_body_template.html
@@ -24,6 +24,10 @@
     width: 80%;
   }
 
+  .references ul {
+    line-height: 150%;
+  }
+
   .carpet-wrapper {
     margin-top: 30px;
   }
@@ -177,9 +181,12 @@
   <div class="about">
     <h1>About tedana</h1>
     $about
-
+  </div>
+  <div class="references">
     <h1>References</h1>
-    $references
+    <ul>
+      $references
+    </ul>
   </div>
 </div>
 

--- a/tedana/reporting/html_report.py
+++ b/tedana/reporting/html_report.py
@@ -62,15 +62,12 @@ def _inline_citations(text, bibliography):
     updated_text = text
 
     for citation in citations:
-        start_idx = citation[0]
         citekey = citation[1]
-        latex_cite_length = len("\\citep{") + len(citekey) + 1
-        end_idx = start_idx + latex_cite_length
+        matched_string = "\\citep{" + citekey + "}"
 
         # Convert citation form latex to html
         html_citation = f"({_cite2html(bibliography, citekey)})"
-
-        updated_text = updated_text[:start_idx] + html_citation + updated_text[end_idx:]
+        updated_text = updated_text.replace(matched_string, html_citation, 1)
 
     return updated_text
 

--- a/tedana/reporting/html_report.py
+++ b/tedana/reporting/html_report.py
@@ -39,8 +39,9 @@ def _cite2html(bibliography, citekey):
         # Get first author
         first_author = bibliography.entries[key].persons["author"][0]
 
-        # Keep surname only (whatever is before the comma)
-        first_author = str(first_author).split(",")[0]
+        # Keep surname only (whatever is before the comma, if there is a comma)
+        if "," in str(first_author):
+            first_author = str(first_author).split(",")[0]
 
         # Get publication year
         pub_year = bibliography.entries[key].fields["year"]

--- a/tedana/reporting/html_report.py
+++ b/tedana/reporting/html_report.py
@@ -27,7 +27,7 @@ def _bib2html(bibliography):
     parser = bibtex.Parser()
     bibliography = parser.parse_file(bibliography)
     formatted_bib = APA.format_bibliography(bibliography)
-    bibliography_str = "<br>".join(entry.text.render(HTML) for entry in formatted_bib)
+    bibliography_str = "".join(f"<li>{entry.text.render(HTML)}</li>" for entry in formatted_bib)
     return bibliography_str, bibliography
 
 

--- a/tedana/reporting/html_report.py
+++ b/tedana/reporting/html_report.py
@@ -150,8 +150,6 @@ def _update_template_bokeh(bokeh_id, info_table, about, prefix, references, boke
     # Update inline citations
     about = _inline_citations(about, bibliography)
 
-    breakpoint()
-
     body_template_name = "report_body_template.html"
     body_template_path = resource_path.joinpath(body_template_name)
     with open(str(body_template_path)) as body_file:

--- a/tedana/resources/references.bib
+++ b/tedana/resources/references.bib
@@ -19,7 +19,7 @@
 }
 
 @manual{bokehmanual,
-  author = {{Bokeh Development Team}},
+  author = {Bokeh Development Team},
   title  = {Bokeh: Python library for interactive visualization},
   url    = {https://bokeh.pydata.org/en/latest/},
   year   = {2018}

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -855,7 +855,7 @@ def tedana_workflow(
         "This workflow used numpy \\citep{van2011numpy}, scipy \\citep{virtanen2020scipy}, "
         "pandas \\citep{mckinney2010data,reback2020pandas}, "
         "scikit-learn \\citep{pedregosa2011scikit}, "
-        "nilearn, bokeh \\citep{bokehmanual}, matplotlib \\citep{Hunter:2007}, "
+        "nilearn, bokeh \\citep{bokehmanual}, matplotlib \\citep{Hunter2007}, "
         "and nibabel \\citep{brett_matthew_2019_3233118}."
     )
 


### PR DESCRIPTION
Changes:

- Fix: Recognize underscores in keys when looking for inline citations
- Fix: The inline citations were using index/offsets to replace the keys with the html citation, but the indices become increasingly outdated after each replacement, so future replacements were spliced into incorrect location. Modified version uses `str.replace` instead.
- Change: The bibliography is now rendered as a list to make it easier to style
  + I also created a new style for the bibliography because the old version was splitting everything into newlines/blocks. 

Disclaimer: I didn't run the full testing suite, so no guarantees 